### PR TITLE
Update port_compiler to work with OTP27

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
             warn_export_all]}.
 
 {plugins, [
-{pc, {git, "https://github.com/blt/port_compiler.git", {tag, "v1.10.2"}}}
+{pc, {git, "https://github.com/blt/port_compiler.git", {tag, "v1.15.0"}}}
 ]}.
 
 {provider_hooks, [


### PR DESCRIPTION
Update the port_compiler plugin from 1.10.2 to 1.15.0 
so it can compile with OTP27: https://github.com/blt/port_compiler/pull/80
The breaking change in OTP27 is the deprecation of code:lib_dir/2
