### PR TITLE
Dev/william/improve perf

### DIFF
--- a/c_src/crc32c.h
+++ b/c_src/crc32c.h
@@ -28,6 +28,11 @@
 
 #pragma once
 
+#if defined(__x86_64__)
+#define WITH_CRC32C_HW 1
+#define RD_INLINE inline
+#endif
+
 typedef unsigned int uint32_t;
 
 uint32_t crc32c(uint32_t crc, const void *buf, size_t len);

--- a/c_src/crc32c_nif.c
+++ b/c_src/crc32c_nif.c
@@ -10,7 +10,8 @@ static ERL_NIF_TERM crc32c_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
   }
 
   ErlNifBinary bin;
-  if(!enif_inspect_iolist_as_binary(env, argv[1], &bin)) {
+  if(!(enif_inspect_binary(env, argv[1], &bin) ||
+       enif_inspect_iolist_as_binary(env, argv[1], &bin))) {
     return enif_make_badarg(env);
   }
 

--- a/src/crc32cer.erl
+++ b/src/crc32cer.erl
@@ -56,6 +56,14 @@ basic_test_() ->
      end}
   ].
 
+perf_test() ->
+    Data = binary:copy(list_to_binary(license_txt()), 400),
+    {Elapsed, ok} = timer:tc(fun() ->
+                                     lists:foreach(fun(_) -> crc32cer:nif(Data) end, lists:seq(1, 1000))
+                             end, millisecond),
+    io:format("Size: ~p, Elapsed time: ~p ms~n", [byte_size(Data), Elapsed]),
+    ?assert(Elapsed < 100).
+
 license_crc() ->
   16#7dcde113.
 


### PR DESCRIPTION
Improve performance:
1. use hardware acceleration on x86_64
2. avoid deep copy when input is binary